### PR TITLE
Fixes a path issue with when the loc module loads

### DIFF
--- a/Source/BYGLocalization/Private/BYGLocalizationModule.cpp
+++ b/Source/BYGLocalization/Private/BYGLocalizationModule.cpp
@@ -56,7 +56,11 @@ void FBYGLocalizationModule::ReloadLocalizations()
 
 	// GameStrings is the ID we use for our currently-used string table
 	// For example it could be French if the player has chosen to use French
-	const FString Filename = Loc->GetFileWithPathFromLanguageCode( Settings->PrimaryLanguageCode );
+	FString Filename = Loc->GetFileWithPathFromLanguageCode( Settings->PrimaryLanguageCode );
+
+	// Remove any project paths from the filename because Internal_LocTableFromFile will factor them in
+	Filename = Filename.Replace( TEXT( "/Game/" ), TEXT("") );
+	
 	StringTableIDs.Add( FName( *Settings->StringtableID ) );
 	FStringTableRegistry::Get().Internal_LocTableFromFile( StringTableIDs[ 0 ], Settings->StringtableNamespace, Filename, FPaths::ProjectContentDir() );
 


### PR DESCRIPTION
If you change the Primary Localization Directory path using the editor drop down, it will append /Game/* to the front. So for the stats window, that is expected as it gives us /Game/*/loc_en.csv. However, when loading in the string table, it will also use that path resulting in /Content//Game/*/loc_en.csv. This fix removes any project paths from the file name because Internal_LocTableFromFile factors the project path in.