### PR TITLE
Fix path logic and validation for UE5

### DIFF
--- a/Source/BYGLocalization/Private/BYGLocalization.cpp
+++ b/Source/BYGLocalization/Private/BYGLocalization.cpp
@@ -52,12 +52,9 @@ TArray<FString> UBYGLocalization::GetAllLocalizationFiles() const
 	for ( const FDirectoryPath& Path : Paths )
 	{
 		IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-		// Directory Path will probably be /Game/Somethingd
-		FString LocalizationDirPath = Path.Path.Replace( TEXT( "/Game" ), *FPaths::ProjectContentDir() );
-		FPaths::RemoveDuplicateSlashes( LocalizationDirPath );
-		bool bFound = false;
-		TArray<FString> LocalFiles;
-		PlatformFile.IterateDirectoryRecursively( *LocalizationDirPath, [&bFound, &PlatformFile, &Files, &Settings]( const TCHAR* InFilenameOrDirectory, const bool bIsDir ) -> bool
+		// Directory Path will probably be /Localization
+		FString LocalizationDirPath = *FPaths::ProjectContentDir() / Path.Path;
+		PlatformFile.IterateDirectoryRecursively( *LocalizationDirPath, [&Files, &Settings]( const TCHAR* InFilenameOrDirectory, const bool bIsDir ) -> bool
 		{
 			// Find all .txt/.csv files in a dir
 			if ( !bIsDir )
@@ -68,7 +65,6 @@ TArray<FString> UBYGLocalization::GetAllLocalizationFiles() const
 					&& ( Settings->FilenameSuffix.IsEmpty() || BaseName.EndsWith( Settings->FilenameSuffix ) ) )
 				{
 					FString NewPath = InFilenameOrDirectory;
-					FPaths::RemoveDuplicateSlashes( NewPath );
 					FPaths::MakePathRelativeTo( NewPath, *FPaths::ProjectContentDir() );
 					Files.Add( NewPath );
 				}
@@ -76,7 +72,6 @@ TArray<FString> UBYGLocalization::GetAllLocalizationFiles() const
 			// return true to continue searching
 			return true;
 		} );
-		Files.Append( LocalFiles );
 	}
 
 	return Files;

--- a/Source/BYGLocalization/Private/BYGLocalizationSettings.cpp
+++ b/Source/BYGLocalization/Private/BYGLocalizationSettings.cpp
@@ -6,7 +6,7 @@
 
 UBYGLocalizationSettings::UBYGLocalizationSettings( const FObjectInitializer& ObjectInitializer )
 {
-	PrimaryLocalizationDirectory.Path = "/Localization/";
+	PrimaryLocalizationDirectory.Path = "Localization";
 }
 
 

--- a/Source/BYGLocalization/Private/BYGLocalizationSettings.cpp
+++ b/Source/BYGLocalization/Private/BYGLocalizationSettings.cpp
@@ -33,6 +33,18 @@ bool UBYGLocalizationSettings::Validate()
 		bAnyChanges = true;
 	}
 
+	if ( PrimaryLocalizationDirectory.Path.StartsWith( TEXT( "/" ) ) )
+	{
+		PrimaryLocalizationDirectory.Path = PrimaryLocalizationDirectory.Path.RightChop( 1 );
+		bAnyChanges = true;
+	}
+
+	if ( PrimaryLocalizationDirectory.Path.StartsWith( TEXT( "Game/" ) ) )
+	{
+		PrimaryLocalizationDirectory.Path = PrimaryLocalizationDirectory.Path.RightChop( 5 );
+		bAnyChanges = true;
+	}
+
 	if ( bUpdateLocsWithCommandLineFlag && CommandLineFlag.IsEmpty() )
 	{
 		CommandLineFlag = "UpdateLoc";
@@ -57,6 +69,7 @@ void UBYGLocalizationSettings::PostEditChangeProperty( struct FPropertyChangedEv
 		|| ( PropertyChangedEvent.GetPropertyName() == GET_MEMBER_NAME_CHECKED( UBYGLocalizationSettings, AllowedExtensions ) )
 		)
 	{
+		Validate();
 		FBYGLocalizationModule::Get().ReloadLocalizations();
 	}
 


### PR DESCRIPTION
I have not tested this on any other engine version than the bleeding edge UE 5.1.0 but it should work on other version too. This fixes the same issue that #1 fixes, but in a more correct and thorough way that should be less prone to future breakage.